### PR TITLE
Remove default-features = false

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2021"
 
 [dependencies]
 color-eyre = { version = "0.6.1", features = ["url", "issue-url"] }
-dialoguer = { version = "0.10.1", default-features = false }
+dialoguer = "0.10.1"
 indicatif = "0.16.2"


### PR DESCRIPTION
`default-features = false` is unnecessary bloat in the Cargo.toml file, and it additionally ruins the clear readability of the "packagename = version" format. By removing this, the code has become even shorter, albeit by a small amount.